### PR TITLE
feat(core): update plugin for October CMS v4 compatibility

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -1,16 +1,24 @@
-<?php namespace Chkilel\Icones;
+<?php
+
+namespace Chkilel\Icones;
 
 use ApplicationException;
 use Backend;
-use System\Classes\PluginBase;
 use Chkilel\Icones\Classes\JsonIcon;
 use Chkilel\Icones\FormWidgets\IconesFinder;
-use Chkilel\Icones\Models\Settings;
+use System\Classes\PluginBase;
 
 class Plugin extends PluginBase
 {
-    public function registerComponents()
+    public function pluginDetails()
     {
+        return [
+            'name' => 'chkilel.icones::lang.plugin.name',
+            'description' => 'chkilel.icones::lang.plugin.description',
+            'author' => 'Adil Chehabi <Chkilel>',
+            'icon' => 'icon-bomb',
+            'homepage' => 'https://github.com/chkilel/icones-plugin',
+        ];
     }
 
     public function registerSettings()
@@ -24,29 +32,26 @@ class Plugin extends PluginBase
                 'category' => 'system::lang.system.categories.cms',
                 'order' => 500,
                 'permissions' => ['chkilel.icones.access_settings'],
-                'keywords' => 'svg icones icon iconify'
+                'keywords' => 'svg icones icon iconify',
             ],
         ];
     }
 
-
     public function registerFormWidgets()
     {
         return [
-            IconesFinder::class => 'iconesfinder'
+            IconesFinder::class => 'iconesfinder',
         ];
     }
-
 
     public function registerMarkupTags()
     {
         return [
             'filters' => [
-                'iconify' => [$this, 'iconify']
+                'iconify' => [$this, 'iconify', false],
             ],
         ];
     }
-
 
     public function registerListColumnTypes()
     {
@@ -55,25 +60,27 @@ class Plugin extends PluginBase
         ];
     }
 
-
     /**
-     * @param $value the Array value on which the filter is applied
-     * @param $props associative array with the folowing possible keys (see REEDME.md):
-     * 'class','width', 'height', 'inline', 'hFlip', 'vFlip', 'flip', 'rotate', 'align', 'color', 'box'
+     * @param  $value  the Array value on which the filter is applied
+     * @param  $props  associative array with the folowing possible keys (see REEDME.md):
+     *                'class','width', 'height', 'inline', 'hFlip', 'vFlip', 'flip', 'rotate', 'align', 'color', 'box'
      * @return string SVG icon
+     *
      * @throws ApplicationException
      */
     public function iconify($iconArray, $props = [])
     {
         $icon = new JsonIcon($iconArray);
+
         return $icon->iconify($props);
     }
 
     /**
-     * @param $value the Array representation of the icon
-     * @param $column column definition object
-     * @param $record  model record object.
+     * @param  $value  the Array representation of the icon
+     * @param  $column  column definition object
+     * @param  $record  model record object.
      * @return string SVG icon
+     *
      * @throws ApplicationException
      */
     public function iconThumbListColumn($value, $column, $record)

--- a/assets/settings.css
+++ b/assets/settings.css
@@ -6,7 +6,7 @@
 .theme-selector-layout .theme-description p {opacity:0.6;filter:alpha(opacity=60)}
 .theme-selector-layout .theme-description h3 {margin:0 0 25px 0;font-size:28px;color:#2b3e50;display:inline-block}
 .theme-selector-layout .theme-description p.author {font-size:13px;display:inline-block;color:#808c8d}
-.theme-selector-layout .theme-description p.description {color:#2b3e50;font-size:14px;line-height:180%;margin-bottom:30px}
+.theme-selector-layout .theme-description p.description {color:#2b3e50;font-size:14px;line-height:180%;}
 .theme-selector-layout .theme-description .controls .btn >i {margin-right:5px;font-size:16px;position:relative;top:1px}
 .theme-selector-layout .theme-description .controls .btn >i.icon-star {color:#f1a84e}
 .theme-selector-layout .theme-description .controls .dropdown {display:inline-block}
@@ -64,7 +64,7 @@
     display: grid;
     grid-template-columns:
     repeat(3, minmax(0, 1fr));
-    row-gap: 4em;
+    row-gap: 2em;
     column-gap: 2em;
     align-content: center;
 }
@@ -87,4 +87,3 @@
 .description {
     text-align: center;
 }
-

--- a/classes/Helpers.php
+++ b/classes/Helpers.php
@@ -1,16 +1,17 @@
-<?php namespace Chkilel\Icones\Classes;
+<?php
 
+namespace Chkilel\Icones\Classes;
+
+use ApplicationException;
 use Chkilel\Icones\Models\Icon;
 use Chkilel\Icones\Models\IconSet;
-use ApplicationException;
 use Iconify\JSONTools\Collection as IconifyCollection;
 
 class Helpers
 {
-
     /**
      * Results returned for the searched term,
-     * @param $perPage
+     *
      * @return array
      */
     public static function searcheIcons($perPage = 20)
@@ -48,7 +49,6 @@ class Helpers
             ->with('iconSet')
             ->simplePaginate($perPage);
 
-
         // Select2 pagination ("infinite scrolling") for remote data sources
         // needs an object with 'results' and  'pagination'
         // Here we construct the results, and we return it beside the pagination parameter
@@ -57,34 +57,33 @@ class Helpers
         foreach ($paginator->Items() as $index => $icon) {
             // If icon is hidden. That means icon was removed from collection for some reason,
             // but it is kept in JSON file to prevent applications that rely on old icon from breaking
-            if (!$icon->hidden) {
+            if (! $icon->hidden) {
                 $icon['svg'] = $icon->toSVG([
                     'height' => Helpers::setSvgHeight($fieldSize),
                     'inline' => true]);
-                $icon['readable_name'] = $showName ?  $icon['name']: '' ;
-                $icon['icon_set_name'] = $showIconSetName ?  $icon['icon_set_name']: '' ;
+                $icon['readable_name'] = $showName ? $icon['name'] : '';
+                $icon['icon_set_name'] = $showIconSetName ? $icon['icon_set_name'] : '';
                 $results[$index] = $icon;
             }
         }
 
         return [
             'results' => $results,
-            'pagination' => ['more' => $paginator->hasMorePages()]
+            'pagination' => ['more' => $paginator->hasMorePages()],
         ];
     }
-
 
     /**
      * Seed Icons for a specific Icon Set, used in the backend settings.
      *
-     * @param $prefix String icon set name abbreviation
+     * @param  $prefix  String icon set name abbreviation
      * @return bool to confirm seeding ok
      */
     public static function installIconSet($prefix)
     {
         $iconsToSave = [];
 
-        $iconSet = new IconifyCollection();
+        $iconSet = new IconifyCollection;
         $iconSet->loadIconifyCollection($prefix);
 
         // List of Icons' names including icons' Aliases
@@ -123,27 +122,32 @@ class Helpers
             $iconsToSave[] = $iconData;
         }
 
-
         // For optimal seeding, because number of icons can be huge
         $chunks = array_chunk($iconsToSave, 200);
 
         foreach ($chunks as $chunk) {
             Icon::insert($chunk);
         }
+
         return true;
     }
 
     /**
      * Mape the arry representation of icon's attributes to an Icon model
-     * @param $iconArray
+     *
      * @return Icon
      */
     public static function mapIcon($iconArray)
     {
+
+        if ($iconArray instanceof Icon) {
+            return $iconArray;
+        }
+
         $keys = [
-            "id", "icon_set_id", "name", "parent", "icon_set_name", "readable_name", "body", "hidden",
-            "left", "top", "width", "height", "rotate", "hFlip", "vFlip",
-            "inlineTop", "inlineHeight", "verticalAlign"
+            'id', 'icon_set_id', 'name', 'parent', 'icon_set_name', 'readable_name', 'body', 'hidden',
+            'left', 'top', 'width', 'height', 'rotate', 'hFlip', 'vFlip',
+            'inlineTop', 'inlineHeight', 'verticalAlign',
         ];
 
         // We check if the given value is an Array  representation of an icon.
@@ -151,16 +155,16 @@ class Helpers
         $isIcon = count(array_diff($keys, $iconArrayKeys)) == 0;
 
         if ($isIcon) {
-            //Although we could grab the model by its Id,  We construct the object from the array,
+            // Although we could grab the model by its Id,  We construct the object from the array,
             // in case the icon is no more in DB if the icon set is deleted for example
-            $icon = new Icon();
+            $icon = new Icon;
             foreach ($iconArray as $key => $attribute) {
                 $icon->{$key} = $attribute;
             }
         } else {
-            throw new ApplicationException(trans("chkilel.icones::lang.formwidgets.error_wrong_variable_type", [
+            throw new ApplicationException(trans('chkilel.icones::lang.formwidgets.error_wrong_variable_type', [
                 'variable' => $iconArray,
-                'type' =>gettype($iconArray),
+                'type' => gettype($iconArray),
             ]));
         }
 
@@ -169,7 +173,8 @@ class Helpers
 
     /**
      * Set the size of the svg depending on the field size option
-     * @param $size small|large
+     *
+     * @param  $size  small|large
      * @return int
      */
     public static function setSvgHeight($fieldSize)
@@ -177,6 +182,7 @@ class Helpers
         if ($fieldSize == 'large') {
             return 24;
         }
+
         return 16;
     }
 }

--- a/classes/JsonIcon.php
+++ b/classes/JsonIcon.php
@@ -1,4 +1,6 @@
-<?php namespace Chkilel\Icones\Classes;
+<?php
+
+namespace Chkilel\Icones\Classes;
 
 use Chkilel\Icones\Models\Icon;
 
@@ -15,19 +17,20 @@ class JsonIcon
         }
     }
 
-
     /**
      * Get SVG from Icon model
-     * @param array $props Options for generating SVG
+     *
+     * @param  array  $props  Options for generating SVG
      * @return string
+     *
      * @throws ApplicationException
      */
     public function iconify($props = [])
     {
         if ($this->icon) {
             // Merge the provided classes with icon classes
-            $iconClass = "icones " . $this->icon->icon_set_id . " " . $this->icon->name;
-            $iconClass .= (isset($props['class']) ? " " . $props['class'] : '');
+            $iconClass = 'icones '.$this->icon->icon_set_id.' '.$this->icon->name;
+            $iconClass .= (isset($props['class']) ? ' '.$props['class'] : '');
 
             $props = array_merge($props, ['class' => $iconClass]);
 

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
-        "composer/installers": "~1.0",
+        "php": ">=8.2",
+        "composer/installers": "~2.0",
         "iconify/json": "^2.1.41",
         "iconify/json-tools": "^1.0"
     },

--- a/controllers/Settings.php
+++ b/controllers/Settings.php
@@ -1,4 +1,6 @@
-<?php namespace Chkilel\Icones\Controllers;
+<?php
+
+namespace Chkilel\Icones\Controllers;
 
 use Backend\Classes\Controller;
 use BackendMenu;
@@ -9,7 +11,6 @@ use System\Classes\SettingsManager;
 
 class Settings extends Controller
 {
-
     public $requiredPermissions = ['chkilel.icones.access_settings'];
 
     /**
@@ -20,7 +21,7 @@ class Settings extends Controller
 
         parent::__construct();
 
-        $this->addCss('/plugins/chkilel/icones/controllers/settings/assets/settings.css', 'Chkilel.Icones');
+        $this->addCss('/plugins/chkilel/icones/assets/settings.css');
 
         $this->pageTitle = 'chkilel.icones::lang.settings.title';
         BackendMenu::setContext('October.System', 'system', 'settings');
@@ -30,7 +31,7 @@ class Settings extends Controller
          * Custom redirect for unauthorized request
          */
         $this->bindEvent('page.beforeDisplay', function () {
-            if (!$this->user->hasAccess('chkilel.icones.access_settings')) {
+            if (! $this->user->hasAccess('chkilel.icones.access_settings')) {
                 return Backend::redirect('backend/system/settings');
             }
         });
@@ -44,7 +45,9 @@ class Settings extends Controller
 
     /**
      * Handler for installing iconset
+     *
      * @return array|void
+     *
      * @throws \SystemException
      */
     public function index_onInstall()
@@ -60,8 +63,9 @@ class Settings extends Controller
             $iconSet->save();
             \Flash::success(trans('chkilel.icones::lang.settings.flash_installed'));
             $this->vars['iconSetsPaginator'] = $this->iconSetsPaginator(1);
+
             return [
-                '#icon-sets-list' => $this->makePartial('icon-sets_list')
+                '#icon-sets-list' => $this->makePartial('icon-sets_list'),
             ];
         } else {
             \Flash::error(trans('chkilel.icones::lang.settings.flash_error_installation'));
@@ -70,6 +74,7 @@ class Settings extends Controller
 
     /**
      * @return array|void
+     *
      * @throws \SystemException
      */
     public function index_onDelete()
@@ -84,8 +89,9 @@ class Settings extends Controller
 
             $this->vars['iconSetsPaginator'] = $this->iconSetsPaginator(1);
             \Flash::success(trans('chkilel.icones::lang.settings.flash_deleted'));
+
             return [
-                '#icon-sets-list' => $this->makePartial('icon-sets_list')
+                '#icon-sets-list' => $this->makePartial('icon-sets_list'),
             ];
         } else {
             \Flash::error(trans('chkilel.icones::lang.settings.flash_error_deletion'));
@@ -94,6 +100,7 @@ class Settings extends Controller
 
     /**
      * @return array|void
+     *
      * @throws \SystemException
      */
     public function index_onEnable()
@@ -104,15 +111,15 @@ class Settings extends Controller
             ->where('icon_set_id', $prefix)
             ->restore();
 
-
         if ($restoredRows > 0) {
             $iconSet = IconSet::find($prefix);
             $iconSet->is_enabled = true;
             $iconSet->save();
             $this->vars['iconSetsPaginator'] = $this->iconSetsPaginator(1);
             \Flash::success(trans('chkilel.icones::lang.settings.flash_enabled'));
+
             return [
-                '#icon-sets-list' => $this->makePartial('icon-sets_list')
+                '#icon-sets-list' => $this->makePartial('icon-sets_list'),
             ];
         } else {
             \Flash::error(trans('chkilel.icones::lang.settings.flash_error_enabling'));
@@ -121,6 +128,7 @@ class Settings extends Controller
 
     /**
      * @return array|void
+     *
      * @throws \SystemException
      */
     public function index_onDisable()
@@ -136,25 +144,25 @@ class Settings extends Controller
             $iconSet->save();
             $this->vars['iconSetsPaginator'] = $this->iconSetsPaginator(1);
             \Flash::success(trans('chkilel.icones::lang.settings.flash_disabled'));
+
             return [
-                '#icon-sets-list' => $this->makePartial('icon-sets_list')
+                '#icon-sets-list' => $this->makePartial('icon-sets_list'),
             ];
         } else {
             \Flash::error(trans('chkilel.icones::lang.settings.flash_error_disabling'));
         }
     }
 
-
     public function onPaginate()
     {
         $page = post('page');
 
         $this->vars['iconSetsPaginator'] = $this->iconSetsPaginator($page);
+
         return [
-            '#icon-sets-list' => $this->makePartial('icon-sets_list')
+            '#icon-sets-list' => $this->makePartial('icon-sets_list'),
         ];
     }
-
 
     public function iconSetsPaginator($page)
     {
@@ -185,6 +193,7 @@ class Settings extends Controller
                 if ($value->withTrashedIcons->count() > 0) {
                     $value->withTrashedIcons = $value->withTrashedIcons->random(9);
                 }
+
                 return $value;
             });
         });

--- a/controllers/settings/_icon-sets_list.htm
+++ b/controllers/settings/_icon-sets_list.htm
@@ -1,18 +1,12 @@
-<?php $iconSetsWithSamples = $iconSetsPaginator->items(); ?>
+<?php $iconSetsWithSamples = $iconSetsPaginator->items(); ?> <?php foreach ($iconSetsWithSamples as
+$index => $iconSet) : ?> <?php $active = $iconSet->isEnabled() ? ' active' : null; $installed =
+$iconSet->isInstalled() && !$iconSet->isEnabled() ? ' installed' : null ?>
 
-<?php foreach ($iconSetsWithSamples as $index => $iconSet) : ?>
-
-    <?php
-    $active = $iconSet->isEnabled() ? ' active' : null;
-    $installed = $iconSet->isInstalled() && !$iconSet->isEnabled() ? ' installed' : null
-    ?>
-
-    <div id="themeListItem-<?= $iconSet->id ?>" class="layout-row min-size <?= $active . $installed ?>">
-        <?= $this->makePartial('icon-sets_list_item', ['iconSet' => $iconSet]) ?>
-    </div>
+<div id="themeListItem-<?= $iconSet->id ?>" class="layout-row min-size <?= $active . $installed ?>">
+    <?= $this->makePartial('icon-sets_list_item', ['iconSet' => $iconSet]) ?>
+</div>
 
 <?php endforeach ?>
-
 
 <div class="layout-row links">
     <div class="layout-cell theme-thumbnail">
@@ -21,7 +15,7 @@
 
     <div class="layout-cell theme-description m-b-lg">
         <div class="loading-indicator-container">
-            <div class="loading-indicator indicator-center" style="display: none;">
+            <div class="loading-indicator indicator-center" style="display: none">
                 <span></span>
             </div>
         </div>
@@ -32,5 +26,4 @@
         </div>
         <!-- END Pagination -->
     </div>
-
 </div>

--- a/controllers/settings/_icon-sets_list_item.htm
+++ b/controllers/settings/_icon-sets_list_item.htm
@@ -1,38 +1,62 @@
 <?php //dd($this->user->hasAccess('chkilel.icones.manage_installation')); ?>
 
-<div id="test" class="layout-cell min-height theme-thumbnail">
+<div class="layout-cell min-height theme-thumbnail">
     <div class="thumbnail-container-flex min-height">
         <div class="icon-grid">
             <?php foreach ($iconSet->withTrashedIcons as $index => $icon): ?>
 
-                <span style="border-left: 0px solid #e4e4e4; border-right: 0px solid #e4e4e4; display: flex; justify-content: center; justify-items: center">
-                    <?= $icon->toSVG(['height' => $iconSet->display_height * 1.4]); ?>
-                </span>
+            <span
+                style="
+                    border-left: 0px solid #e4e4e4;
+                    border-right: 0px solid #e4e4e4;
+                    display: flex;
+                    justify-content: center;
+                    justify-items: center;
+                "
+            >
+                <?= $icon->toSVG(['height' => 36]); ?>
+            </span>
             <?php endforeach ?>
         </div>
     </div>
 </div>
 
-
 <div class="layout-cell min-height theme-description">
     <h3><?= e($iconSet->name) ?></h3>
     <?php if (strlen($iconSet->url)): ?>
-        <p class="author">
-            <?= trans('chkilel.icones::lang.settings.by_author', ['name' => '<a href="' . e($iconSet->url) . '" target="_blank">' . e($iconSet->author) . '</a>']) ?>
-        </p>
+    <p class="author">
+        <?= trans('chkilel.icones::lang.settings.by_author', ['name' => '<a
+            href="' . e($iconSet->url) . '"
+            target="_blank"
+            >' . e($iconSet->author) . '</a
+        >']) ?>
+    </p>
     <?php else: ?>
-        <p class="author">
-            <?= trans('chkilel.icones::lang.settings.by_author', ['name' => '<span>' . e($iconSet->author) . '</span>']) ?>
-        </p>
+    <p class="author">
+        <?= trans('chkilel.icones::lang.settings.by_author', ['name' => '<span
+            >' . e($iconSet->author) . '</span
+        >']) ?>
+    </p>
     <?php endif ?>
 
     <div class="scoreboard">
-
         <div class="scoreboard-item title-value">
             <h4 class=""><?= $iconSet->category ?? 'Uncategorized'; ?></h4>
             <p class="svg-container">
-                <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="36" height="36" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">
-                    <path d="M18.514 2.23l3.448 3.447a2 2 0 0 1 .463 2.103l-1.763 4.812a1 1 0 0 1-.232.363l-8.323 8.323a2 2 0 0 1-2.829 0l-6.364-6.364a2 2 0 0 1 0-2.828l8.333-8.333a1 1 0 0 1 .364-.232l4.802-1.755a2 2 0 0 1 2.101.464zM15.29 8.904a1.5 1.5 0 1 0 2.12-2.122a1.5 1.5 0 0 0-2.12 2.122z" fill="#34495e" />
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                    aria-hidden="true"
+                    role="img"
+                    width="36"
+                    height="36"
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 24 24"
+                >
+                    <path
+                        d="M18.514 2.23l3.448 3.447a2 2 0 0 1 .463 2.103l-1.763 4.812a1 1 0 0 1-.232.363l-8.323 8.323a2 2 0 0 1-2.829 0l-6.364-6.364a2 2 0 0 1 0-2.828l8.333-8.333a1 1 0 0 1 .364-.232l4.802-1.755a2 2 0 0 1 2.101.464zM15.29 8.904a1.5 1.5 0 1 0 2.12-2.122a1.5 1.5 0 0 0-2.12 2.122z"
+                        fill="#34495e"
+                    />
                 </svg>
             </p>
         </div>
@@ -40,71 +64,126 @@
             <h4 class=""><?= $iconSet->palette? 'Colourful' : 'Colorless'; ?></h4>
             <p class="svg-container">
                 <?php if ($iconSet->palette == 0): ?>
-                    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="36" height="36" preserveAspectRatio="xMidYMid meet" viewBox="0 0 48 48">
-                        <path fill="#8CBCD6" d="M40 41H8c-2.2 0-4-1.8-4-4V11c0-2.2 1.8-4 4-4h32c2.2 0 4 1.8 4 4v26c0 2.2-1.8 4-4 4z" />
-                        <circle fill="#B3DDF5" cx="35" cy="16" r="3" />
-                        <path fill="#9AC9E3" d="M20 16L9 32h22z" />
-                        <path fill="#B3DDF5" d="M31 22l-8 10h16z" />
-                        <circle fill="#F44336" cx="38" cy="38" r="10" />
-                        <g fill="#fff">
-                            <path d="M43.31 41.181l-2.12 2.122l-8.485-8.484l2.121-2.122z" />
-                            <path d="M34.819 43.31l-2.122-2.12l8.484-8.485l2.122 2.121z" />
-                        </g>
-                    </svg>
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                    aria-hidden="true"
+                    role="img"
+                    width="36"
+                    height="36"
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 48 48"
+                >
+                    <path
+                        fill="#8CBCD6"
+                        d="M40 41H8c-2.2 0-4-1.8-4-4V11c0-2.2 1.8-4 4-4h32c2.2 0 4 1.8 4 4v26c0 2.2-1.8 4-4 4z"
+                    />
+                    <circle fill="#B3DDF5" cx="35" cy="16" r="3" />
+                    <path fill="#9AC9E3" d="M20 16L9 32h22z" />
+                    <path fill="#B3DDF5" d="M31 22l-8 10h16z" />
+                    <circle fill="#F44336" cx="38" cy="38" r="10" />
+                    <g fill="#fff">
+                        <path d="M43.31 41.181l-2.12 2.122l-8.485-8.484l2.121-2.122z" />
+                        <path d="M34.819 43.31l-2.122-2.12l8.484-8.485l2.122 2.121z" />
+                    </g>
+                </svg>
                 <?php else: ?>
-                    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="36" height="36" preserveAspectRatio="xMidYMid meet" viewBox="0 0 48 48">
-                        <path fill="#E65100" d="M41 42H13c-2.2 0-4-1.8-4-4V18c0-2.2 1.8-4 4-4h28c2.2 0 4 1.8 4 4v20c0 2.2-1.8 4-4 4z" />
-                        <path fill="#F57C00" d="M35 36H7c-2.2 0-4-1.8-4-4V12c0-2.2 1.8-4 4-4h28c2.2 0 4 1.8 4 4v20c0 2.2-1.8 4-4 4z" />
-                        <circle fill="#FFF9C4" cx="30" cy="16" r="3" />
-                        <path fill="#942A09" d="M17 17.9L8 31h18z" />
-                        <path fill="#BF360C" d="M28 23.5L22 31h12z" />
-                    </svg>
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                    aria-hidden="true"
+                    role="img"
+                    width="36"
+                    height="36"
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 48 48"
+                >
+                    <path
+                        fill="#E65100"
+                        d="M41 42H13c-2.2 0-4-1.8-4-4V18c0-2.2 1.8-4 4-4h28c2.2 0 4 1.8 4 4v20c0 2.2-1.8 4-4 4z"
+                    />
+                    <path
+                        fill="#F57C00"
+                        d="M35 36H7c-2.2 0-4-1.8-4-4V12c0-2.2 1.8-4 4-4h28c2.2 0 4 1.8 4 4v20c0 2.2-1.8 4-4 4z"
+                    />
+                    <circle fill="#FFF9C4" cx="30" cy="16" r="3" />
+                    <path fill="#942A09" d="M17 17.9L8 31h18z" />
+                    <path fill="#BF360C" d="M28 23.5L22 31h12z" />
+                </svg>
                 <?php endif ?>
             </p>
         </div>
 
-        <?php if ($iconSet->is_installed): ?>
-            <?php if ($iconSet->is_enabled): ?>
-                <div class="scoreboard-item title-value success">
-                    <h4 class="">Enabled</h4>
-                    <p class="svg-container">
-                        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="36" height="36" preserveAspectRatio="xMidYMid meet" viewBox="0 0 48 48">
-                            <circle fill="#4CAF50" cx="24" cy="24" r="21" />
-                            <path fill="#CCFF90" d="M34.6 14.6L21 28.2l-5.6-5.6l-2.8 2.8l8.4 8.4l16.4-16.4z" />
-                        </svg>
-                    </p>
-                </div>
-            <?php else: ?>
-                <div class="scoreboard-item title-value success">
-                    <h4 class="">Disabled</h4>
-                    <p class="svg-container">
-                        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="36" height="36" preserveAspectRatio="xMidYMid meet" viewBox="0 0 48 48">
-                            <circle fill="#2196F3" cx="24" cy="24" r="21" />
-                            <path fill="#fff" d="M22 22h4v11h-4z" />
-                            <circle fill="#fff" cx="24" cy="16.5" r="2.5" />
-                        </svg>
-                    </p>
-                </div>
-            <?php endif; ?>
-
+        <?php if ($iconSet->is_installed): ?> <?php if ($iconSet->is_enabled): ?>
+        <div class="scoreboard-item title-value success">
+            <h4 class="">Enabled</h4>
+            <p class="svg-container">
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                    aria-hidden="true"
+                    role="img"
+                    width="36"
+                    height="36"
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 48 48"
+                >
+                    <circle fill="#4CAF50" cx="24" cy="24" r="21" />
+                    <path
+                        fill="#CCFF90"
+                        d="M34.6 14.6L21 28.2l-5.6-5.6l-2.8 2.8l8.4 8.4l16.4-16.4z"
+                    />
+                </svg>
+            </p>
+        </div>
         <?php else: ?>
-            <div class="scoreboard-item title-value success">
-                <h4 class="">Not installed</h4>
-                <p class="svg-container">
-                    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="36" height="36" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24">
-                        <path d="M14.8 4.613l6.701 11.161c.963 1.603.49 3.712-1.057 4.71a3.213 3.213 0 0 1-1.743.516H5.298C3.477 21 2 19.47 2 17.581c0-.639.173-1.264.498-1.807L9.2 4.613c.962-1.603 2.996-2.094 4.543-1.096c.428.276.79.651 1.057 1.096zM12 17a1 1 0 1 0 0-2a1 1 0 0 0 0 2zm0-9a1 1 0 0 0-1 1v4a1 1 0 0 0 2 0V9a1 1 0 0 0-1-1z" fill="#c53d2d" />
-                    </svg>
-                </p>
-            </div>
+        <div class="scoreboard-item title-value success">
+            <h4 class="">Disabled</h4>
+            <p class="svg-container">
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                    aria-hidden="true"
+                    role="img"
+                    width="36"
+                    height="36"
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 48 48"
+                >
+                    <circle fill="#2196F3" cx="24" cy="24" r="21" />
+                    <path fill="#fff" d="M22 22h4v11h-4z" />
+                    <circle fill="#fff" cx="24" cy="16.5" r="2.5" />
+                </svg>
+            </p>
+        </div>
+        <?php endif; ?> <?php else: ?>
+        <div class="scoreboard-item title-value success">
+            <h4 class="">Not installed</h4>
+            <p class="svg-container">
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                    aria-hidden="true"
+                    role="img"
+                    width="36"
+                    height="36"
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 24 24"
+                >
+                    <path
+                        d="M14.8 4.613l6.701 11.161c.963 1.603.49 3.712-1.057 4.71a3.213 3.213 0 0 1-1.743.516H5.298C3.477 21 2 19.47 2 17.581c0-.639.173-1.264.498-1.807L9.2 4.613c.962-1.603 2.996-2.094 4.543-1.096c.428.276.79.651 1.057 1.096zM12 17a1 1 0 1 0 0-2a1 1 0 0 0 0 2zm0-9a1 1 0 0 0-1 1v4a1 1 0 0 0 2 0V9a1 1 0 0 0-1-1z"
+                        fill="#c53d2d"
+                    />
+                </svg>
+            </p>
+        </div>
         <?php endif; ?>
 
         <div class="scoreboard-item title-value">
             <h4>Total icons</h4>
             <p class="number-icon"><?= $iconSet->total; ?></p>
             <p class="description">
-                <?php if ($iconSet->version): ?>
-                    V<?= $iconSet->version; ?>
-                <?php endif; ?>
+                <?php if ($iconSet->version): ?> V<?= $iconSet->version; ?> <?php endif; ?>
             </p>
         </div>
 
@@ -112,96 +191,113 @@
             <h4>License</h4>
             <p class="license">
                 <?php if ($iconSet->license_url): ?>
-                    <a href="<?= $iconSet->license_url; ?>" target="_blank">
-                        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" style="vertical-align: -0.125em;" width="24" height="24" preserveAspectRatio="xMidYMid meet" viewBox="0 0 512 512">
-                            <path d="M432 320h-32a16 16 0 0 0-16 16v112H64V128h144a16 16 0 0 0 16-16V80a16 16 0 0 0-16-16H48a48 48 0 0 0-48 48v352a48 48 0 0 0 48 48h352a48 48 0 0 0 48-48V336a16 16 0 0 0-16-16zM488 0H360c-21.37 0-32.05 25.91-17 41l35.73 35.73L135 320.37a24 24 0 0 0 0 34L157.67 377a24 24 0 0 0 34 0l243.61-243.68L471 169c15 15 41 4.5 41-17V24a24 24 0 0 0-24-24z" fill="#0f86e4" />
-                        </svg>
-                    </a>
-                <?php endif; ?>
-                <?= $iconSet->license; ?>
+                <a href="<?= $iconSet->license_url; ?>" target="_blank">
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                        aria-hidden="true"
+                        role="img"
+                        style="vertical-align: -0.125em"
+                        width="24"
+                        height="24"
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 512 512"
+                    >
+                        <path
+                            d="M432 320h-32a16 16 0 0 0-16 16v112H64V128h144a16 16 0 0 0 16-16V80a16 16 0 0 0-16-16H48a48 48 0 0 0-48 48v352a48 48 0 0 0 48 48h352a48 48 0 0 0 48-48V336a16 16 0 0 0-16-16zM488 0H360c-21.37 0-32.05 25.91-17 41l35.73 35.73L135 320.37a24 24 0 0 0 0 34L157.67 377a24 24 0 0 0 34 0l243.61-243.68L471 169c15 15 41 4.5 41-17V24a24 24 0 0 0-24-24z"
+                            fill="#0f86e4"
+                        />
+                    </svg>
+                </a>
+                <?php endif; ?> <?= $iconSet->license; ?>
             </p>
         </div>
     </div>
 
-
     <div class="controls">
-
         <?php if ($iconSet->isInstalled()): ?>
 
-            <!--    Icon set INSTALLED   -->
-            <?php if ($iconSet->isEnabled()): ?>
-                <!--    Icon set ACTIVE   -->
-                <button
-                    type="submit"
-                    data-request="onDisable"
-                    data-request-data="iconSet: '<?= $iconSet->id ?>'"
-                    data-stripe-load-indicator
-                    class="btn btn-danger">
-                    <i class="oc-icon-eye-slash"></i>
-                    <?= e(trans('chkilel.icones::lang.settings.disable_button')) ?>
-                </button>
+        <!--    Icon set INSTALLED   -->
+        <?php if ($iconSet->isEnabled()): ?>
+        <!--    Icon set ACTIVE   -->
+        <button
+            type="submit"
+            data-request="onDisable"
+            data-request-data="iconSet: '<?= $iconSet->id ?>'"
+            data-stripe-load-indicator
+            class="btn btn-danger"
+        >
+            <i class="oc-icon-eye-slash"></i>
+            <?= e(trans('chkilel.icones::lang.settings.disable_button')) ?>
+        </button>
 
-                <?php if ($this->user->hasAccess('chkilel.icones.manage_installation')): ?>
-                    <div class="dropdown">
-                        <a data-toggle="dropdown" class="btn btn-secondary"> <i class="oc-icon-trash"></i>
-                            <?= e(trans('chkilel.icones::lang.settings.delete_button')) ?>
-                        </a>
-                        <ul class="dropdown-menu" role="menu" data-dropdown-title="<?= e(trans('chkilel.icones::lang.settings.delete_title')) ?>">
-                            <li role="presentation">
-                                <div class="callout callout-warning">
-                                    <div class="content">
-                                        <p>
-                                            <i class="oc-icon-warning"></i> <?= e(trans('chkilel.icones::lang.settings.cant_delete_enabled')) ?>
-                                        </p>
-                                    </div>
-                                </div>
-                            </li>
-                        </ul>
+        <?php if ($this->user->hasAccess('chkilel.icones.manage_installation')): ?>
+        <div class="dropdown">
+            <a data-toggle="dropdown" class="btn btn-secondary">
+                <i class="oc-icon-trash"></i>
+                <?= e(trans('chkilel.icones::lang.settings.delete_button')) ?>
+            </a>
+            <ul
+                class="dropdown-menu"
+                role="menu"
+                data-dropdown-title="<?= e(trans('chkilel.icones::lang.settings.delete_title')) ?>"
+            >
+                <li role="presentation">
+                    <div class="callout callout-warning" style="margin-bottom: 0; min-width: 300px">
+                        <div class="header">
+                            <i class="oc-icon-warning"></i> <?=
+                            e(trans('chkilel.icones::lang.settings.cant_delete_enabled')) ?>
+                        </div>
                     </div>
-                <?php endif ?>
+                </li>
+            </ul>
+        </div>
+        <?php endif ?>
 
-                <!--   end Icon set ACTIVE   -->
-            <?php else: ?>
-                <!--    Icon set DISABLED   -->
-                <button
-                    type="submit"
-                    data-request="onEnable"
-                    data-request-data="iconSet: '<?= $iconSet->id ?>'"
-                    data-stripe-load-indicator
-                    class="btn btn-primary">
-                    <i class="oc-icon-eye"></i>
-                    <?= e(trans('chkilel.icones::lang.settings.enable_button')) ?>
-                </button>
-                <?php if ($this->user->hasAccess('chkilel.icones.manage_installation')): ?>
-                    <button
-                        type="submit"
-                        data-request="onDelete"
-                        data-request-confirm="<?= e(trans('chkilel.icones::lang.settings.delete_confirm')) ?>"
-                        data-request-data="iconSet: '<?= $iconSet->id ?>'"
-                        data-stripe-load-indicator
-                        class="btn btn-primary">
-                        <i class="oc-icon-trash"></i>
-                        <?= e(trans('chkilel.icones::lang.settings.delete_button')) ?>
-                    </button>
-                <?php endif ?>
-                <!--   end Icon set DISABLED   -->
-            <?php endif ?>
-            <!--    end Icon set INSTALLED   -->
+        <!--   end Icon set ACTIVE   -->
+        <?php else: ?>
+        <!--    Icon set DISABLED   -->
+        <button
+            type="submit"
+            data-request="onEnable"
+            data-request-data="iconSet: '<?= $iconSet->id ?>'"
+            data-stripe-load-indicator
+            class="btn btn-primary"
+        >
+            <i class="oc-icon-eye"></i>
+            <?= e(trans('chkilel.icones::lang.settings.enable_button')) ?>
+        </button>
+        <?php if ($this->user->hasAccess('chkilel.icones.manage_installation')): ?>
+        <button
+            type="submit"
+            data-request="onDelete"
+            data-request-confirm="<?= e(trans('chkilel.icones::lang.settings.delete_confirm')) ?>"
+            data-request-data="iconSet: '<?= $iconSet->id ?>'"
+            data-stripe-load-indicator
+            class="btn btn-danger"
+        >
+            <i class="oc-icon-trash"></i>
+            <?= e(trans('chkilel.icones::lang.settings.delete_button')) ?>
+        </button>
+        <?php endif ?>
+        <!--   end Icon set DISABLED   -->
+        <?php endif ?>
+        <!--    end Icon set INSTALLED   -->
 
         <?php else: ?>
 
-            <!--    Icon set NOT YET INSTALLED   -->
-            <button
-                type="submit"
-                data-request="onInstall"
-                data-request-data="iconSet: '<?= $iconSet->id ?>'"
-                data-stripe-load-indicator
-                class="btn btn-success">
-                <i class="oc-icon-download"></i>
-                <?= e(trans('chkilel.icones::lang.settings.install_button')) ?>
-            </button>
-            <!--   end Icon set NOT YET INSTALLED   -->
+        <!--    Icon set NOT YET INSTALLED   -->
+        <button
+            type="submit"
+            data-request="onInstall"
+            data-request-data="iconSet: '<?= $iconSet->id ?>'"
+            data-stripe-load-indicator
+            class="btn btn-success"
+        >
+            <i class="oc-icon-download"></i>
+            <?= e(trans('chkilel.icones::lang.settings.install_button')) ?>
+        </button>
+        <!--   end Icon set NOT YET INSTALLED   -->
         <?php endif ?>
-
     </div>
 </div>

--- a/controllers/settings/index.htm
+++ b/controllers/settings/index.htm
@@ -12,7 +12,7 @@
 
 <script>
     function scrollToTop() {
-        $('html, body').animate({scrollTop : 0},700);
-        return false;
+        $('html, body').animate({ scrollTop: 0 }, 700)
+        return false
     }
 </script>

--- a/formwidgets/IconesFinder.php
+++ b/formwidgets/IconesFinder.php
@@ -1,4 +1,6 @@
-<?php namespace Chkilel\Icones\FormWidgets;
+<?php
+
+namespace Chkilel\Icones\FormWidgets;
 
 use Backend\Classes\FormWidgetBase;
 use Chkilel\Icones\Classes\Helpers;
@@ -29,22 +31,22 @@ class IconesFinder extends FormWidgetBase
     public $size = '';
 
     /**
-     * @var String Placeholder to display.
+     * @var string Placeholder to display.
      */
     public $placeholder = '';
 
     /**
-     * @var array  Set the icon sets to choose from.
+     * @var array Set the icon sets to choose from.
      */
     public $iconSets = [];
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     protected $defaultAlias = 'iconesfinder';
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function init()
     {
@@ -58,11 +60,12 @@ class IconesFinder extends FormWidgetBase
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function render()
     {
         $this->prepareVars();
+
         return $this->makePartial('iconesfinder');
     }
 
@@ -80,7 +83,7 @@ class IconesFinder extends FormWidgetBase
         $this->vars['showIconSetName'] = $this->showIconSetName;
         $this->vars['size'] = $this->size;
 
-        if (!is_array($this->iconSets)) {
+        if (! is_array($this->iconSets)) {
             $this->iconSets = explode('|', $this->iconSets);
         }
         $this->vars['iconSets'] = $this->iconSets;
@@ -88,13 +91,13 @@ class IconesFinder extends FormWidgetBase
 
         $this->vars['svgProps'] = [
             'inline' => true,
-            'height' => Helpers::setSvgHeight($this->size)
+            'height' => Helpers::setSvgHeight($this->size),
         ];
         $this->vars['sizeClass'] = $this->setSizeClass($this->size);
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function loadAssets()
     {
@@ -104,7 +107,7 @@ class IconesFinder extends FormWidgetBase
     /**
      * Store value as a Json string or null
      *
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function getSaveValue($value)
     {
@@ -127,9 +130,8 @@ class IconesFinder extends FormWidgetBase
         return $serialized;
     }
 
-
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function getLoadValue()
     {
@@ -148,7 +150,7 @@ class IconesFinder extends FormWidgetBase
     /**
      * Return the class to adjust the size of the field
      *
-     * @param $size small|large
+     * @param  $size  small|large
      * @return string
      */
     public function setSizeClass($size)

--- a/formwidgets/iconesfinder/partials/_iconesfinder.htm
+++ b/formwidgets/iconesfinder/partials/_iconesfinder.htm
@@ -4,12 +4,8 @@ if (!empty($placeholder)) {
 }
 ?>
 
-
 <div class="form-group <?= $sizeClass ?>">
-    <select class="form-control icones-finder"
-            id="<?= $id; ?>"
-            name="<?= $name; ?>"
-    >
+    <select class="form-control icones-finder" id="<?= $id; ?>" name="<?= $name; ?>">
         <option value=""></option>
     </select>
 </div>

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -1,4 +1,6 @@
-<?php return [
+<?php
+
+return [
     'plugin' => [
         'name' => 'Icônes',
         'description' => 'Access thousands of icons including popular icon sets, icon fonts and several Emoji sets from a backed Form Widget',
@@ -24,7 +26,7 @@
         'flash_deleted' => 'The Icon Set was deleted succesfully',
         'flash_installed' => 'The Icon Set was installed succesfully',
         'flash_error_installation' => 'Something wrong happened, Icon Set was not installed',
-        'scroll_to_top' =>'To the top'
+        'scroll_to_top' => 'To the top',
     ],
     'permission' => [
         'manage_tab' => 'Icônes',

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -1,34 +1,36 @@
-<?php return [
-    "plugin" => [
-        "name" => "Icônes",
-        "description" => "Accédez à des milliers d'icônes, y compris les librairies d'icônes populaires, des polices d'icônes et plusieurs ensembles d'Emoji à partir d'un seul FormWidget backend",
+<?php
+
+return [
+    'plugin' => [
+        'name' => 'Icônes',
+        'description' => "Accédez à des milliers d'icônes, y compris les librairies d'icônes populaires, des polices d'icônes et plusieurs ensembles d'Emoji à partir d'un seul FormWidget backend",
     ],
-    "formwidgets" => [
-        "placeholder" => "-- Choisir une icône --",
-        "error_wrong_variable_type" => "Le filtre Twig iconify doit être appliqué sur une variable de type Icones, la variable [:variable] est de type [:type]",
+    'formwidgets' => [
+        'placeholder' => '-- Choisir une icône --',
+        'error_wrong_variable_type' => 'Le filtre Twig iconify doit être appliqué sur une variable de type Icones, la variable [:variable] est de type [:type]',
     ],
-    "settings" => [
-        "title" => "Icônes",
-        "label" => "Icônes",
-        "description" => "Gérez plus de 100.000 icônes vectorielles, y compris les librairies d'icônes populaires, des polices d'icônes et plusieurs librairies d'Emoji.",
-        "by_author" => "Par :name",
-        "enable_button" => "Activer",
-        "disable_button" => "Désactiver",
-        "delete_button" => "Supprimer",
-        "cant_delete_enabled" => "Vous ne pouvez pas supprimer les lirairies d'icônes actives, désactivez-les en premier.",
-        "delete_title" => "Les librairies d'icône actives ne peuvent pas être supprimées",
-        "delete_confirm" => "Êtes vous sûr de vouloir supprimer cette librairie?",
-        "install_button" => "Installer",
-        "flash_enabled" => "La librairie d'icônes est maintenant activées",
-        "flash_disabled" => "La librairie d'icônes est maintenant désactivées",
-        "flash_deleted" => "La librairie d'icônes est supprimées corrêctement",
-        "flash_installed" => "L'installation est terminées avec succès",
-        "flash_error_installation" => "Une ereur est survenue, la librairie d'icônes n'est pas installées",
-        "scroll_to_top" =>"Vers le haut"
+    'settings' => [
+        'title' => 'Icônes',
+        'label' => 'Icônes',
+        'description' => "Gérez plus de 100.000 icônes vectorielles, y compris les librairies d'icônes populaires, des polices d'icônes et plusieurs librairies d'Emoji.",
+        'by_author' => 'Par :name',
+        'enable_button' => 'Activer',
+        'disable_button' => 'Désactiver',
+        'delete_button' => 'Supprimer',
+        'cant_delete_enabled' => "Vous ne pouvez pas supprimer les lirairies d'icônes actives, désactivez-les en premier.",
+        'delete_title' => "Les librairies d'icône actives ne peuvent pas être supprimées",
+        'delete_confirm' => 'Êtes vous sûr de vouloir supprimer cette librairie?',
+        'install_button' => 'Installer',
+        'flash_enabled' => "La librairie d'icônes est maintenant activées",
+        'flash_disabled' => "La librairie d'icônes est maintenant désactivées",
+        'flash_deleted' => "La librairie d'icônes est supprimées corrêctement",
+        'flash_installed' => "L'installation est terminées avec succès",
+        'flash_error_installation' => "Une ereur est survenue, la librairie d'icônes n'est pas installées",
+        'scroll_to_top' => 'Vers le haut',
     ],
-    "permission" => [
-        "manage_tab" => "Icônes",
-        "access_settings" => "Accéder aux paramètres d'Icônes",
-        "manage_installation" => "Gérer l'installation et la suppression des librairies d'icônes",
+    'permission' => [
+        'manage_tab' => 'Icônes',
+        'access_settings' => "Accéder aux paramètres d'Icônes",
+        'manage_installation' => "Gérer l'installation et la suppression des librairies d'icônes",
     ],
 ];

--- a/models/Icon.php
+++ b/models/Icon.php
@@ -1,104 +1,52 @@
-<?php namespace Chkilel\Icones\Models;
+<?php
+
+namespace Chkilel\Icones\Models;
 
 use Iconify\JSONTools\SVG;
 use Model;
+use October\Rain\Database\Traits\SoftDelete;
+use October\Rain\Database\Traits\Validation;
 
-/**
- * Icon Model
- */
 class Icon extends Model
 {
-    use \October\Rain\Database\Traits\Validation;
-    use \October\Rain\Database\Traits\SoftDelete;
+    use SoftDelete;
+    use Validation;
 
-
-    /**
-     * @var string The database table used by the model.
-     */
     public $table = 'chkilel_icones_icons';
 
-    /**
-     * @var array Guarded fields
-     */
     protected $guarded = ['*'];
 
-    /**
-     * @var array Fillable fields
-     */
-    protected $fillable = [];
-
-    /**
-     * @var array Validation rules for attributes
-     */
     public $rules = [];
 
-    /**
-     * @var array Attributes to be cast to native types
-     */
-    protected $casts = [];
-
-    /**
-     * @var array Attributes to be cast to JSON
-     */
-    protected $jsonable = [];
-
-    /**
-     * @var array Attributes to be appended to the API representation of the model (ex. toArray())
-     */
-    protected $appends = [];
-
-    /**
-     * @var array Attributes to be removed from the API representation of the model (ex. toArray())
-     */
     protected $hidden = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
-    /**
-     * @var array Attributes to be cast to Argon (Carbon) instances
-     */
-    protected $dates = [
-        'created_at',
-        'updated_at',
-        'deleted_at'
+    protected $casts = [
+        'left' => 'integer',
+        'top' => 'integer',
+        'width' => 'integer',
+        'height' => 'integer',
+        'rotate' => 'integer',
+        'inlineTop' => 'integer',
+        'inlineHeight' => 'integer',
+        'verticalAlign' => 'float',
+        'hidden' => 'boolean',
+        'hFlip' => 'boolean',
+        'vFlip' => 'boolean',
     ];
 
-    /**
-     * @var array Relations
-     */
-    public $hasOne = [];
-    public $hasMany = [];
-    public $hasOneThrough = [];
-    public $hasManyThrough = [];
     public $belongsTo = [
-        'iconSet' => \Chkilel\Icones\Models\IconSet::class,
+        'iconSet' => IconSet::class,
     ];
-    public $belongsToMany = [];
-    public $morphTo = [];
-    public $morphOne = [];
-    public $morphMany = [];
-    public $attachOne = [];
-    public $attachMany = [];
 
-    /**
-     * @param $query
-     * @return mixed
-     */
     public function scopeWithTrashedIcons($query)
     {
         return $query->withTrashed();
     }
 
-
-    /**
-     * Get the svg from an Icon model
-     *
-     * @param $props associative array with the folowing possible keys (see REEDME.md):
-     * 'class','width', 'height', 'inline', 'hFlip', 'vFlip', 'flip', 'rotate', 'align', 'color', 'box'
-     * @return string
-     */
     public function toSVG($props = [])
     {
         $svg = new SVG($this->getArrayableAttributes());

--- a/models/IconSet.php
+++ b/models/IconSet.php
@@ -1,136 +1,66 @@
-<?php namespace Chkilel\Icones\Models;
+<?php
+
+namespace Chkilel\Icones\Models;
 
 use Model;
+use October\Rain\Database\Traits\SoftDelete;
+use October\Rain\Database\Traits\Validation;
 
-/**
- * IconSet Model
- */
 class IconSet extends Model
 {
-    use \October\Rain\Database\Traits\Validation;
-    use \October\Rain\Database\Traits\SoftDelete;
+    use SoftDelete;
+    use Validation;
 
-
-    /**
-     * @var string The database table used by the model.
-     */
     public $table = 'chkilel_icones_icon_sets';
 
-
-    /**
-     * Indicates if the IDs are auto-incrementing.
-     * @var bool
-     */
     public $incrementing = false;
 
-    /**
-     * The "type" of the ID.
-     * @var string
-     */
     protected $keyType = 'string';
 
-    /**
-     * @var array Guarded fields
-     */
     protected $guarded = ['*'];
 
-    /**
-     * @var array Fillable fields
-     */
-    protected $fillable = [];
-
-    /**
-     * @var array Validation rules for attributes
-     */
     public $rules = [];
 
-    /**
-     * @var array Attributes to be cast to native types
-     */
     protected $casts = [
         'is_enabled' => 'boolean',
         'is_installed' => 'boolean',
         'palette' => 'boolean',
+        'height' => 'array',
+        'samples' => 'array',
+        'display_height' => 'integer',
+        'total' => 'integer',
     ];
 
-    /**
-     * @var array Attributes to be cast to JSON
-     */
     protected $jsonable = [
         'height',
-        'samples'
+        'samples',
     ];
 
-    /**
-     * @var array Attributes to be appended to the API representation of the model (ex. toArray())
-     */
-    protected $appends = [];
-
-    /**
-     * @var array Attributes to be removed from the API representation of the model (ex. toArray())
-     */
     protected $hidden = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
-    /**
-     * @var array Attributes to be cast to Argon (Carbon) instances
-     */
-    protected $dates = [
-        'created_at',
-        'updated_at',
-        'deleted_at'
-    ];
-
-    /**
-     * @var array Relations
-     */
-    public $hasOne = [];
     public $hasMany = [
-        //'icons' => \Chkilel\Icones\Models\Icon::class,
         'withTrashedIcons' => [
-            \Chkilel\Icones\Models\Icon::class,
+            Icon::class,
             'scope' => 'withTrashedIcons',
-        ]
+        ],
     ];
-    public $hasOneThrough = [];
-    public $hasManyThrough = [];
-    public $belongsTo = [];
-    public $belongsToMany = [];
-    public $morphTo = [];
-    public $morphOne = [];
-    public $morphMany = [];
-    public $attachOne = [];
-    public $attachMany = [];
 
-
-    /**
-     * @return boolean
-     * True if Icon Set is enabled
-     */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
         return $this->is_enabled;
     }
 
-    /**
-     * @return boolean
-     * True if the Icon Set is installed
-     */
-    public function isInstalled()
+    public function isInstalled(): bool
     {
         return $this->is_installed;
     }
 
-    /**
-     * Number of icon to showcase on the setting page
-     * @return Icon collection of icons
-     */
     public function iconsToShowcase()
     {
         return $this->withTrashedIcons()->inRandomOrder()->take(9);
-//        return $this->icons()->take(9);
     }
 }

--- a/routes.php
+++ b/routes.php
@@ -1,7 +1,6 @@
-<?php namespace Chkilel\Icones;
+<?php
 
 use Chkilel\Icones\Classes\Helpers;
+use Illuminate\Support\Facades\Route;
 
-use Route;
-
-Route::get('icons', Helpers::class.'@searcheIcons');
+Route::middleware(['web'])->get('icons', Helpers::class.'@searcheIcons');

--- a/updates/change_body_datatype_in_icons_table.php
+++ b/updates/change_body_datatype_in_icons_table.php
@@ -1,23 +1,12 @@
-<?php namespace Chkilel\Icones\Updates;
+<?php
 
-use Schema;
-use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
-class updateBodyIconsTable extends Migration
+return new class extends Migration
 {
-    public function up()
-    {
-        Schema::table('chkilel_icones_icons', function (Blueprint $table) {
-            // Svg body without <svg> tag
-            $table->mediumText('body')->change();
-        });
+    public function up() {
     }
 
-    public function down()
-    {
-        Schema::table('chkilel_icones_icons', function (Blueprint $table) {
-            $table->text('body')->change();
-        });
+    public function down() {
     }
-}
+};

--- a/updates/create_icon_sets_table.php
+++ b/updates/create_icon_sets_table.php
@@ -1,63 +1,30 @@
-<?php namespace Chkilel\Icones\Updates;
+<?php
 
-use Schema;
 use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
+use Illuminate\Support\Facades\Schema;
 
-class CreateIconSetsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
         Schema::create('chkilel_icones_icon_sets', function (Blueprint $table) {
             $table->engine = 'InnoDB';
 
-            // Prefix for the icon set used as Id
             $table->string('id');
-
-            // Icon set's name. This field is always set.
             $table->string('name');
-
-            // The total number of icons, optional.
             $table->integer('total')->nullable();
-
-            // Author name. This field is always set.
             $table->string('author');
-
-            // Link to icon set, optional. Usually links to GitHub repository.
             $table->string('url')->nullable();
-
-            // License title. This field is always set.
             $table->string('license');
-
-            // Link to the license, optional.
             $table->string('license_url')->nullable();
-
-            // The current version, optional.
             $table->string('version')->nullable();
-
-            // Value is an array of icon names that should be used
-            // as samples when showing the icon set in an icon sets list.
             $table->text('samples')->nullable();
-
-            // Colorless or Colorful
             $table->string('palette')->nullable();
-
-            // Category of the icon set
             $table->string('category')->nullable();
-
-            // Is the icon set enabled in the backend or not
             $table->boolean('is_enabled')->default(false);
-
-            // Is the icon set seeded to the database
             $table->boolean('is_installed')->default(false);
-
-            // Value is a number or array of numbers,
-            // values are pixel grids used in the icon set.
-            // If any icons in an icon set do not match the grid, this attribute should not be set.
             $table->string('height')->default(16);
-
-            // The height value that should be used for displaying samples.
-            // Value is a number between 16 and 30 (inclusive).
             $table->integer('display_height')->default(24);
 
             $table->timestamp('created_at')->nullable();
@@ -72,4 +39,4 @@ class CreateIconSetsTable extends Migration
     {
         Schema::dropIfExists('chkilel_icones_icon_sets');
     }
-}
+};

--- a/updates/create_icons_table.php
+++ b/updates/create_icons_table.php
@@ -1,80 +1,38 @@
-<?php namespace Chkilel\Icones\Updates;
+<?php
 
-use Schema;
 use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
+use Illuminate\Support\Facades\Schema;
 
-class CreateIconsTable extends Migration
+return new class extends Migration
 {
-    /**
-     *   IconesJSON object might include any of the optional properties,
-     *   They are used as default values for icons that do not have those properties.
-     *
-     *   Properties for viewBox:
-     *       - left, number. Left position of viewBox. Default value is 0.
-     *       - top, number. Top position of viewBox. Default value is 0.
-     *       - width, number. Width of viewBox. Default value is 16.
-     *       - height, number. Height of viewBox. Default value is 16.
-     *
-     *   Transformations:
-     *       - rotate, number. Number of 90 degrees rotations. Default value is 0.
-     *       - hFlip, boolean. Horizontal flip. Default value is false.
-     *       - vFlip, boolean. Vertical flip. Default value is false.
-     *
-     *   Hidden icons:
-     *      - If hidden  set to true, icon is hidden. That means icon was removed from collection for some reason,
-     *        but it is kept in JSON file to prevent applications that rely on old icon from breaking
-     **/
-
     public function up()
     {
         Schema::create('chkilel_icones_icons', function (Blueprint $table) {
             $table->engine = 'InnoDB';
             $table->increments('id')->unsigned();
 
-            // Icon set Prefix
             $table->string('icon_set_id');
-
-            //Icon name, dashed name
             $table->string('name');
-
-            //Icon name, Readable name
             $table->string('readable_name');
-
-            // Parent name if is Alias
             $table->string('parent')->nullable();
-
-            // Icon set readable name
             $table->string('icon_set_name');
 
-            // Svg body without <svg> tag
-            $table->text('body');
+            $table->mediumText('body');
 
-            // If icon is hidden. That means icon was removed from collection for some reason,
-            // but it is kept in JSON file to prevent applications that rely on old icon from breaking
             $table->boolean('hidden')->default(false);
 
-            //  Properties for viewBox:
-            $table->integer('left'); // Relevant to Alias
-            $table->integer('top'); // Relevant to Alias
-
-            // width and height are dimensions of icon. Value can be string (such as "1em", "24px" or a number).
-            //  - If only one dimension is set, another dimension will be set using icon's width/height ratio.
-            //  - If value is "auto", icon's original dimensions will be used.
-            //  - If both width and height are not set, height defaults to "1em".
+            $table->integer('left');
+            $table->integer('top');
             $table->integer('width');
             $table->integer('height');
 
-            //   Transformations
             $table->integer('rotate');
             $table->boolean('hFlip');
             $table->boolean('vFlip');
 
             $table->integer('inlineTop');
             $table->integer('inlineHeight');
-
-            // Inline icons are aligned slightly below baseline,
-            // so they look centred compared to text, like glyph fonts.
             $table->float('verticalAlign', 8, 4);
 
             $table->timestamp('created_at')->nullable();
@@ -87,4 +45,4 @@ class CreateIconsTable extends Migration
     {
         Schema::dropIfExists('chkilel_icones_icons');
     }
-}
+};

--- a/updates/seed_icon_sets_table.php
+++ b/updates/seed_icon_sets_table.php
@@ -1,8 +1,10 @@
-<?php namespace Chkilel\Icones\Updates;
+<?php
+
+namespace Chkilel\Icones\Updates;
 
 use Chkilel\Icones\Models\IconSet;
 use Iconify\IconsJSON\Finder;
-use Seeder;
+use October\Rain\Database\Updates\Seeder;
 
 class SeedIconSetsTable extends Seeder
 {
@@ -13,18 +15,14 @@ class SeedIconSetsTable extends Seeder
 
     public function createIconSets(): void
     {
-        // Load all collections' information from "collections-json" library
-        // https://github.com/icones/collections-json/blob/master/collections.json
         $iconSets = Finder::collections();
 
         foreach ($iconSets as $prefix => $iconSet) {
-            $model = new IconSet();
+            $model = new IconSet;
 
             $model->id = $prefix;
             $model->name = $iconSet['name'];
             $model->total = $iconSet['total'];
-
-
             $model->author = $iconSet['author']['name'];
             $model->url = $iconSet['author']['url'] ?? null;
             $model->license = $iconSet['license']['title'];

--- a/updates/upgrade_icon_sets_table.php
+++ b/updates/upgrade_icon_sets_table.php
@@ -1,26 +1,20 @@
 <?php
 
-namespace Chkilel\Icones\Updates;
-
-use Schema;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 
-class UpgradeIconSetsTable extends Migration
+return new class extends Migration
 {
     public function up()
     {
-        //move the value to the new datatype
-        //Colourful => 1, Colorless => 0
         DB::table('chkilel_icones_icon_sets')->where('palette', 'Colorless')->update(['palette' => false]);
         DB::table('chkilel_icones_icon_sets')->where('palette', 'Colorful')->update(['palette' => true]);
 
-        // Change the datatype of the column
         Schema::table('chkilel_icones_icon_sets', function (Blueprint $table) {
             $table->boolean('palette')->change();
         });
-
     }
 
     public function down()
@@ -28,9 +22,8 @@ class UpgradeIconSetsTable extends Migration
         Schema::table('chkilel_icones_icon_sets', function (Blueprint $table) {
             $table->string('palette')->change();
         });
-        //Roll back the value to the old datatype
-        // 1 => Colourful , 0 => Colorless
+
         DB::table('chkilel_icones_icon_sets')->where('palette', '0')->update(['palette' => 'Colorless']);
         DB::table('chkilel_icones_icon_sets')->where('palette', '1')->update(['palette' => 'Colorful']);
     }
-}
+};

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -22,9 +22,16 @@
 3.0.0:
     - 'OCMS 3 compatible version'
 3.0.1:
-    - 'Fix DB erro when installing Iconset'
+    - 'Fix DB error when installing Iconset'
 3.1.0:
     - 'Fix Select2 initial value and clearing functionality'
     - 'Add select2:clear event handler to allow icon deselection'
     - 'Improve HTML escaping for security'
     - 'Add templateResult and templateSelection for consistent display'
+4.0.0:
+    - 'October CMS v4 compatible version'
+    - 'Add PHP 8.2+ requirement and Laravel 12 support'
+    - 'Fix Twig output escaping for iconify filter (raw SVG output)'
+    - 'Use modern anonymous class migrations'
+    - 'Protect icon search route with web middleware'
+    - 'Update composer/installers to ~2.0'


### PR DESCRIPTION
Modernize codebase for Laravel 12 and PHP 8.2+. Convert migrations to anonymous classes, add proper type hints, protect icon search route with web middleware, fix Twig output escaping for iconify filter, update composer/installers to ~2.0, and clean up boilerplate across models, controllers, and views.